### PR TITLE
Release process with Docker image published to ghcr.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,39 @@
+name: release
+on:
+  release:
+    types: [published]
+jobs:
+  build_push_and_publish:
+    runs-on: ubuntu-20.04
+    steps:
+      -
+        name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Log in to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Build Docker image
+        run: make docker-build
+      -
+        name: Push Docker image
+        run: make docker-push
+      -
+        name: Create install.yaml file
+        run: make build/install.yaml
+      -
+        name: Upload install.yaml file
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./build/install.yaml
+          asset_name: install.yaml
+          asset_content_type: text/yaml

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,11 +1,13 @@
 name: test
-on: [pull_request, push]
+on: [pull_request]
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: golang:1.16
     steps:
-      - name: Checkout
+      -
+        name: Checkout
         uses: actions/checkout@v2
-      - name: Run tests
+      -
+        name: Run tests
         run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ bin
 *.swp
 *.swo
 *~
+
+# Build artifacts
+build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.15.5 as builder
+FROM golang:1.16.3 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/README.md
+++ b/README.md
@@ -2,13 +2,36 @@
 
 This is an example of an [External Issuer] for cert-manager.
 
+## Install
+
+```
+kubectl apply -f https://github.com/cert-manager/sample-external-issuer/releases/download/v0.1.0/install.yaml
+```
+
 ## Demo
 
 You can run the sample-external-issuer on a local cluster with this command:
 
 ```
-make IMG=controller:0.0.0 kind-cluster deploy-cert-manager docker-build kind-load deploy e2e
+make kind-cluster deploy-cert-manager docker-build kind-load deploy e2e
 ```
+
+## Release Process
+
+Visit the [GitHub New Release Page][] and fill in the form.
+Here are some example values:
+
+ * Tag Version: `v0.1.0-alpha.0`, `v0.1.0` for example.
+ * Target: `main`
+ * Release Title: `Release v0.1.0-alpha.2`
+ * Description: (optional) a short summery of the changes since the last release.
+
+Click the `Publish release` button to trigger the automated release process:
+
+* A Docker image will be generated and published to `gcr.io/cert-manager/sample-external-issuer/controller` with the chosen tag.
+* An `install.yaml` file will be generated and attached to the release.
+
+[GitHub New Release Page]: https://github.com/cert-manager/sample-external-issuer/releases/new
 
 ## How to write your own external issuer
 


### PR DESCRIPTION
A release process  which is triggered by a developer filling in the GitHub `Create New Release` page.
I considered something which creates the entire GitHub release automatically when ever a new tag is pushed, but this seemed like a good first step, and it think it is  intuitive that a developer can trigger a release using the GitHub UI.

Fixes: #3 

You can test this by creating a pre-release yourself, but based on this `3-publish-docker-image` branch rather than `main` branch.

![image](https://user-images.githubusercontent.com/978965/115848544-e4862180-a41b-11eb-881b-d0e73ccae20e.png)

Then visit the `Actions` tab to see the automated release logs:

![image](https://user-images.githubusercontent.com/978965/115848724-14352980-a41c-11eb-9c4e-4349213c277c.png)

