### PR TITLE
Add an OWNERS file

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,18 @@
+approvers:
+- munnerz
+- joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish
+reviewers:
+- munnerz
+- joshvanl
+- meyskens
+- wallrj
+- jakexks
+- maelvls
+- irbekrm
+- sgtcodfish


### PR DESCRIPTION
An OWNERS file to help prow with the approved label

I copied the content from https://github.com/jetstack/cert-manager/blob/17bf228fbb387f97010f56a8e615a1a5cf294ac4/OWNERS