### PR TITLE
Kubernetes 1.22 deprecated APIs: move rbac.authorization.k8s.io from v1beta1 to v1

### DIFF
--- a/config/rbac/auth_proxy_client_clusterrole.yaml
+++ b/config/rbac/auth_proxy_client_clusterrole.yaml
@@ -1,4 +1,4 @@
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: metrics-reader


### PR DESCRIPTION
As detailed in the [deprecation-guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#rbac-resources-v122), the API version `rbac.authorization.k8s.io/v1` is available since Kubernetes 1.8. In Kubernetes 1.22, `rbac.authorization.k8s.io/v1beta1` will stop being served.