### PR TITLE
Use go install to install controller-gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CERT_MANAGER_VERSION ?= 1.8.0
 
 # Controller tools
 CONTROLLER_GEN_VERSION := 0.5.0
-CONTROLLER_GEN := ${BIN}/controller-gen-${CONTROLLER_GEN_VERSION}
+CONTROLLER_GEN := ${BIN}/controller-gen
 
 INSTALL_YAML ?= build/install.yaml
 
@@ -117,13 +117,7 @@ docker-push:
 	docker push ${IMG}
 
 ${CONTROLLER_GEN}: | ${BIN}
-	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d)
-	trap "rm -rf $${CONTROLLER_GEN_TMP_DIR}" EXIT
-	cd $${CONTROLLER_GEN_TMP_DIR}
-	go mod init tmp
-	GOBIN=$${CONTROLLER_GEN_TMP_DIR} go get sigs.k8s.io/controller-tools/cmd/controller-gen@v${CONTROLLER_GEN_VERSION}
-	mv $${CONTROLLER_GEN_TMP_DIR}/controller-gen ${CONTROLLER_GEN}
-
+	GOBIN=${BIN} go install sigs.k8s.io/controller-tools/cmd/controller-gen@v${CONTROLLER_GEN_VERSION}
 
 # ==================================
 # E2E testing

--- a/internal/issuer/signer/policies.go
+++ b/internal/issuer/signer/policies.go
@@ -37,12 +37,12 @@ type SigningPolicy interface {
 // PermissiveSigningPolicy is the signing policy historically used by the local
 // signer.
 //
-//  * It forwards all SANs from the original signing request.
-//  * It sets allowed usages as configured in the policy.
-//  * It sets NotAfter based on the TTL configured in the policy.
-//  * It zeros all extensions.
-//  * It sets BasicConstraints to true.
-//  * It sets IsCA to false.
+//   - It forwards all SANs from the original signing request.
+//   - It sets allowed usages as configured in the policy.
+//   - It sets NotAfter based on the TTL configured in the policy.
+//   - It zeros all extensions.
+//   - It sets BasicConstraints to true.
+//   - It sets IsCA to false.
 type PermissiveSigningPolicy struct {
 	// TTL is the certificate TTL. It's used to calculate the NotAfter value of
 	// the certificate.


### PR DESCRIPTION
While upgrading go ( #31 ) I noticed that the installation of controller-gen was broken:
```
mv: cannot stat '/tmp/tmp.3YSqYnswQb/controller-gen': No such file or directory
make: *** [Makefile:120: /__w/sample-external-issuer/sample-external-issuer/bin/controller-gen-0.5.0] Error 1
```
-- https://github.com/cert-manager/sample-external-issuer/actions/runs/4676731610/jobs/8283393483?pr=31