### PR TITLE
Bump GHA in workflows to latest major releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,13 +8,13 @@ jobs:
     steps:
       -
         name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       -
         name: Log in to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -28,6 +28,8 @@ jobs:
         run: make build/install.yaml
       -
         name: Upload install.yaml file
+        # NOTE: This action has been deprecated for long.
+        # TODO: We should reengineer the release workflow.
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,8 +4,8 @@ jobs:
   unit:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
           cache: true
@@ -13,13 +13,13 @@ jobs:
   e2e:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: make -j1 kind-cluster deploy-cert-manager docker-build kind-load deploy e2e
       - run: make kind-export-logs E2E_ARTIFACTS_DIRECTORY=build/artifacts/e2e-logs
         if: failure()
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: e2e-logs


### PR DESCRIPTION
The e2e-test workflow in currently failing because we're using an outdated version of an action, ref. https://github.com/cert-manager/sample-external-issuer/actions/runs/13098951689/job/36544774091?pr=53