### PR TITLE
Update OWNERS and add aliases

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,16 +1,4 @@
 approvers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
+- cm-maintainers
 reviewers:
-- munnerz
-- joshvanl
-- wallrj
-- jakexks
-- maelvls
-- irbekrm
-- sgtcodfish
+- cm-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,11 @@
+aliases:
+  cm-maintainers:
+    - munnerz
+    - joshvanl
+    - wallrj
+    - jakexks
+    - maelvls
+    - sgtcodfish
+    - inteon
+    - thatsmrtalbot
+    - erikgb


### PR DESCRIPTION
I just reviewed a couple of PRs in this project and noticed that my LGTM does not count. This PR updates the OWNERS file to include current cert-manager maintainers using OWNER_ALIASES.