### PR TITLE
Onboard Renovate using new shared preset

### DIFF
--- a/.github/chainguard/renovate.sts.yaml
+++ b/.github/chainguard/renovate.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:cert-manager/sample-external-issuer:ref:refs/heads/main
+
+permissions:
+  administration: read
+  contents: write
+  issues: write
+  pull_requests: write
+  security_events: read
+  statuses: write
+  workflows: write

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,6 @@
+{
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
+  extends: [
+    'github>cert-manager/renovate-config:default.json5',
+  ],
+}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,45 @@
+name: Renovate
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+
+    if: github.repository == 'cert-manager/sample-external-issuer'
+
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Octo STS Token Exchange
+        uses: octo-sts/action@e480437973a6f6ac2e9caa40ecabedc870d76395 # v1.0.1
+        id: octo-sts
+        with:
+          scope: 'cert-manager/sample-external-issuer'
+          identity: renovate
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          token: ${{ steps.octo-sts.outputs.token }}
+
+      - uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+        with:
+          go-version-file: go.mod
+
+      - name: Self-hosted Renovate
+        uses: renovatebot/github-action@7876d7a812254599d262d62b6b2c2706018258a2 # v43.0.10
+        with:
+          configurationFile: .github/renovate.json5
+          token: ${{ steps.octo-sts.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          RENOVATE_ONBOARDING: "false"
+          RENOVATE_PLATFORM: "github"
+          LOG_LEVEL: "debug"
+          RENOVATE_ALLOWED_COMMANDS: '[".*"]'


### PR DESCRIPTION
Without makefile-modules. This project is a bit "special", since it probably serves as a template for people who want to create a new external issuer.

But the dependencies in this project are lagging behind, and we have two open PRs to fix some of this. So there is a need. I also want to use this project to test the new shared preset a bit more.